### PR TITLE
Add a polynomial gas model for real gas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(LIBTHERMO_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(thermo_headers
     ${LIBTHERMO_INCLUDE_DIR}/libthermo/gas.h
     ${LIBTHERMO_INCLUDE_DIR}/libthermo/ideal_gas.h
+    ${LIBTHERMO_INCLUDE_DIR}/libthermo/real_gas.h
     ${LIBTHERMO_INCLUDE_DIR}/libthermo/math_utils.h
 )
 

--- a/benchs/main.cc
+++ b/benchs/main.cc
@@ -1,13 +1,16 @@
 #include "libthermo/ideal_gas.h"
+#include "libthermo/real_gas.h"
 
+#ifdef LIBTHERMO_USE_XTENSOR
 #include "xtensor/xtensor.hpp"
+#endif
 
 #include <iostream>
 #include <chrono>
 #include <functional>
 #include <string>
 #include <memory>
-
+#include <vector>
 
 namespace libthermo
 {
@@ -245,6 +248,7 @@ namespace libthermo
         std::cout << "Pout -> " << timeit(bench_pout, ntimes2) << " ns" << std::endl;
     }
 
+#ifdef LIBTHERMO_USE_XTENSOR
     template <class G>
     void benchmark_vector(G&& gas, std::size_t size, long ntimes)
     {
@@ -299,23 +303,51 @@ namespace libthermo
         std::cout << "EffPoly -> " << timeit(bench_EffPoly, ntimes) << " ns" << std::endl;
         std::cout << "Pout -> " << timeit(bench_pout, ntimes) << " ns" << std::endl;
     }
+#endif
 }
 
 int main()
 {
     using namespace libthermo;
+    double Tref = 288.15;
+    {
+        IdealGas gas(287.05287, 1004.685045);
 
-    IdealGas gas(287.05287, 1004.685045);
+        std::cout << "\n" << "Reference values" << std::endl;
+        std::cout << "Cp -> " << gas.Cp(Tref) << std::endl;
+        std::cout << "Gamma -> " << gas.Gamma(Tref) << std::endl;
+        std::cout << "H -> " << gas.H(Tref) << std::endl;
+        std::cout << "Phi -> " << gas.Phi(Tref) << std::endl;
 
-    std::cout << "Single value tests" << std::endl;
-    //benchmark_single_value(gas, 1000000, 50);
+        std::cout << "\nSingle value tests" << std::endl;
+        benchmark_single_value(gas, 1000000, 50);
 
-    std::cout << "\nLoop tests" << std::endl;
-    benchmark_loop(gas, 1000000, 1000);
+        std::cout << "\nLoop tests" << std::endl;
+        benchmark_loop(gas, 1000000, 500);
 
-    std::cout << "\nVector tests" << std::endl;
-    benchmark_vector(gas, 1000000, 1000);
+        std::cout << "\nVector tests" << std::endl;
+        benchmark_vector(gas, 1000000, 500);
+    }
 
+    {
+        RealGas gas(287.05287);
+
+        std::cout << "\n" << "Reference values" << std::endl;
+        std::cout << "Cp -> " << gas.Cp(Tref) << std::endl;
+        std::cout << "Gamma -> " << gas.Gamma(Tref) << std::endl;
+        std::cout << "H -> " << gas.H(Tref) << std::endl;
+        std::cout << "Phi -> " << gas.Phi(Tref) << std::endl;
+
+        std::cout << "\nSingle value tests" << std::endl;
+        benchmark_single_value(gas, 1000000, 50);
+
+        std::cout << "\nLoop tests" << std::endl;
+        benchmark_loop(gas, 1000000, 500);
+
+        std::cout << "\nVector tests" << std::endl;
+        benchmark_vector(gas, 1000000, 500);
+
+    }
     // std::cout << XSIMD_X86_INSTR_SET << std::endl;
 
     return 0;

--- a/benchs/python_benchs.ipy
+++ b/benchs/python_benchs.ipy
@@ -1,4 +1,4 @@
-from build.pythermo.pythermo import IdealGas
+from build.pythermo.pythermo import IdealGas, RealGas
 g = IdealGas(287, 1004)
 
 import numpy as np
@@ -12,10 +12,14 @@ eff = np.repeat(0.8, N)
 res = np.ones_like(t1)
 
 print("Benchmark pythermo")
+%timeit res = g.cp(t1)
 %timeit res = g.phi(t1)
 %timeit res = g.pr(t1, t2, 0.8)
 %timeit res = g.eff_poly(p1, t1, p2, t2)
 
+g2 = RealGas(287.05)
+print("Benchmark pythermo2")
+%timeit res = g2.cp(t1)
 
 class NumpyIdealGas:
 

--- a/include/libthermo/gas.h
+++ b/include/libthermo/gas.h
@@ -7,6 +7,32 @@
 #ifndef LIBTHERMO_GAS_H
 #define LIBTHERMO_GAS_H
 
+#ifdef LIBTHERMO_USE_XTENSOR
+#include "xtensor/xcontainer.hpp"
+#include "xtensor/xtensor.hpp"
+#include "xtensor/xfunction.hpp"
+
+#define IS_NOT_XTENSOR \
+    std::enable_if_t<!xt::detail::is_container<T>::value, int> = 0
+#define IS_XTENSOR \
+    std::enable_if_t<xt::detail::is_container<T>::value, int> = 0
+#else
+#include <type_traits>
+
+namespace
+{
+    template<class T>
+    struct is_tensor : std::false_type {};
+
+    template<class T>
+    struct is_not_tensor : std::true_type {};
+}
+#define IS_NOT_XTENSOR \
+    std::enable_if_t<is_not_tensor<T>::value, int> = 0
+#define IS_XTENSOR \
+    std::enable_if_t<is_tensor<T>::value, int> = 0
+#endif
+
 #include <cmath>
 #include <string>
 #include <memory>
@@ -25,31 +51,31 @@ namespace libthermo
 
         /// Proxy method to compute the specific heat ratio.
         template<class T>
-        T SpecificHeatRatio(const T& t) const { return derived_gas().Gamma(t); };
+        auto SpecificHeatRatio(const T& t) const { return derived_gas().Gamma(t); };
 
         /// Proxy method to compute the specific heat pressure.
         template<class T>
-        T SpecificHeatPressure(const T& t) const { return derived_gas().Cp(t); };
+        auto SpecificHeatPressure(const T& t) const { return derived_gas().Cp(t); };
 
         /// Proxy method to compute the enthalpy.
         template<class T>
-        T Enthalpy(double const &t) const { return derived_gas().H(t); };
+        auto Enthalpy(double const &t) const { return derived_gas().H(t); };
         
         /// Proxy method to compute the entropy.
         template<class T>
-        T Entropy(double const &t) const { return derived_gas().Phi(t); };
+        auto Entropy(double const &t) const { return derived_gas().Phi(t); };
         
         /// Proxy method to get the gas constant.
         template<class T>
-        T Constant() const { return derived_gas().template R<T>(); };
+        auto Constant() const { return derived_gas().template R<T>(); };
         
         /// Proxy method to get the pressure ratio from initiale and finale temps, and polytropic efficiency.
-        template<class T>
-        T PressureRatio(const T& t1, const T& t2, const T& eff_poly) const { return derived_gas().PR(t1, t2, eff_poly); };
+        template<class T, class E>
+        auto PressureRatio(const T& t1, const T& t2, const E& eff_poly) const { return derived_gas().PR(t1, t2, eff_poly); };
         
         /// Proxy method to get the polytropic efficiency of a transformation between initial and final pressure and temps.
         template<class T>
-        T PolytropicEfficiency(const T& p1, const T& t1, const T& p2, const T& t2) const { 
+        auto PolytropicEfficiency(const T& p1, const T& t1, const T& p2, const T& t2) const { 
             return derived_gas().EffPoly(p1, t1, p2, t2); } 
 
     protected:

--- a/include/libthermo/ideal_gas.h
+++ b/include/libthermo/ideal_gas.h
@@ -7,32 +7,6 @@
 #ifndef LIBTHERMO_IDEAL_GAS_H
 #define LIBTHERMO_IDEAL_GAS_H
 
-#ifdef LIBTHERMO_USE_XTENSOR
-#include "xtensor/xcontainer.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xfunction.hpp"
-
-#define IS_NOT_XTENSOR \
-    std::enable_if_t<!xt::detail::is_container<T>::value, int> = 0
-#define IS_XTENSOR \
-    std::enable_if_t<xt::detail::is_container<T>::value, int> = 0
-#else
-#include <type_traits>
-
-namespace
-{
-    template<class T>
-    struct is_tensor : std::false_type {};
-
-    template<class T>
-    struct is_not_tensor : std::true_type {};
-}
-#define IS_NOT_XTENSOR \
-    std::enable_if_t<is_not_tensor<T>::value, int> = 0
-#define IS_XTENSOR \
-    std::enable_if_t<is_tensor<T>::value, int> = 0
-#endif
-
 #include "libthermo/gas.h"
 
 #include <string>
@@ -118,7 +92,8 @@ namespace libthermo
     template<class T, IS_XTENSOR>
     auto IdealGas::Cp(const T& t) const
     {
-        return xt::full_like(t, cp);
+        return xt::broadcast(cp, t.shape());
+        //return xt::full_like(t, cp);
     }
 #endif
 

--- a/include/libthermo/real_gas.h
+++ b/include/libthermo/real_gas.h
@@ -1,0 +1,191 @@
+// Copyright (c) Adrien DELSALLE
+//
+// Distributed under the terms of the BSD 3-Clause License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+
+#ifndef LIBTHERMO_REAL_GAS_H
+#define LIBTHERMO_REAL_GAS_H
+
+#include "libthermo/gas.h"
+
+#include <string>
+
+
+namespace libthermo
+{   
+    template<int D>
+    struct poly
+    {
+        template<class E, class It>
+        static inline auto polyval(E&& x, It coeff)
+        {
+            auto c = coeff++;
+            return *c + x * poly<D-1>::polyval(x, coeff);
+        };
+    };
+
+    template<>
+    struct poly<0>
+    {
+        template<class E, class It>
+        static inline double polyval(E&& x, It coeff)
+        {
+            return *coeff;
+        };
+    };
+
+    template<int I, class T, class It>
+    static inline auto polyval(T&& x, It coeff)
+    {
+        return poly<I>::polyval(x, coeff);
+    };
+
+    class RealGas : public Gas<RealGas>
+    {
+    public:
+        RealGas(double r_)
+            : r(r_)
+        {};
+
+        template<class T, IS_NOT_XTENSOR>
+        auto Gamma(const T& t) const;
+
+        template<class T, IS_XTENSOR>
+        auto Gamma(const T& t) const;
+
+        template<class T>
+        auto Cp(const T& t) const;
+
+        template<class T>
+        auto H(const T& t) const;
+
+        template<class T, IS_NOT_XTENSOR>
+        auto Phi(const T&t) const;
+
+        template<class T, IS_XTENSOR>
+        auto Phi(const T&t) const;
+
+        template<class T, IS_NOT_XTENSOR>
+        auto dPhi(const T& t1, const T& t2) const;
+
+        template<class T, IS_XTENSOR>
+        auto dPhi(const T& t1, const T& t2) const;
+
+        template<class T>
+        auto R() const;
+
+        template<class T, IS_NOT_XTENSOR>
+        auto PR(const T& t1, const T& t2, const T& eff_poly) const;
+
+        template<class T, class E, IS_XTENSOR>
+        auto PR(const T& t1, const T& t2, const E& eff_poly) const;
+
+        template<class T, IS_NOT_XTENSOR>
+        auto EffPoly(const T& p1, const T& t1, const T& p2, const T& t2) const;
+
+        template<class T, IS_XTENSOR>
+        auto EffPoly(const T& p1, const T& t1, const T& p2, const T& t2) const;
+
+    protected:
+        double r;
+
+        static const std::size_t coeff_size = 7;
+        // https://www.cerfacs.fr/antares/_downloads/6d913fcaec57101ff421a2220b0769db/antares_doc.pdf p272
+        const std::array<double, 8> cp_coeff = {2.35822e-20, -1.79613e-16, 4.70972e-13, -3.3094e-10, -6.27984e-07, 0.00123785, -0.521742, 1068.43};
+        const std::array<double, 9> h_coeff = {2.35822e-20 / 8., -1.79613e-16 / 7., 4.70972e-13 / 6., -3.3094e-10 / 5., -6.27984e-07 / 4., 0.00123785 / 3., -0.521742 / 2., 1068.43, 0.};
+        const std::array<double, 9> phi_coeff = {2.35822e-20 / 7., -1.79613e-16 / 6., 4.70972e-13 / 5., -3.3094e-10 / 4., -6.27984e-07 / 3., 0.00123785 / 2., -0.521742, 0., 1068.43};
+
+    };
+
+    template<class T, IS_NOT_XTENSOR>
+    auto RealGas::Gamma(const T& t) const
+    {
+        T tmp_cp = Cp(t);
+        return tmp_cp / (tmp_cp - 287.05);
+    }
+
+#ifdef LIBTHERMO_USE_XTENSOR
+    template<class T, IS_XTENSOR>
+    auto RealGas::Gamma(const T& t) const
+    {
+        T tmp_cp = Cp(t);
+        return xt::eval(tmp_cp / (tmp_cp - 287.05));
+    }
+#endif
+
+    template<class T>
+    auto RealGas::Cp(const T& t) const
+    {
+        return polyval<7>(t, cp_coeff.rbegin());
+    }
+
+    template<class T>
+    auto RealGas::H(const T& t) const
+    {
+        return polyval<8>(t, h_coeff.rbegin());
+    }
+
+    template<class T, IS_NOT_XTENSOR>
+    auto RealGas::Phi(const T& t) const
+    {
+        return polyval<7>(t, ++phi_coeff.rbegin()) + phi_coeff[8] * std::log(t);
+    }
+
+#ifdef LIBTHERMO_USE_XTENSOR
+    template<class T, IS_XTENSOR>
+    auto RealGas::Phi(const T& t) const
+    {
+        return polyval<7>(t, ++phi_coeff.rbegin()) + phi_coeff[8] * xt::log(t);
+    }
+#endif
+
+    template<class T, IS_NOT_XTENSOR>
+    auto RealGas::dPhi(const T& t1, const T& t2) const
+    {
+        return (polyval<7>(t2, ++phi_coeff.rbegin()) - polyval<7>(t1, ++phi_coeff.rbegin())) + phi_coeff[8] * std::log(t2 / t1);
+    }
+
+#ifdef LIBTHERMO_USE_XTENSOR
+    template<class T, IS_XTENSOR>
+    auto RealGas::dPhi(const T& t1, const T& t2) const
+    {
+        return (polyval<7>(t2, ++phi_coeff.rbegin()) - polyval<7>(t1, ++phi_coeff.rbegin())) + phi_coeff[8] * xt::log(t2 / t1);
+    }
+#endif
+
+    template<class T>
+    auto RealGas::R() const
+    {
+        return r; 
+    }
+
+    template<class T, IS_NOT_XTENSOR>
+    auto RealGas::PR(const T& t1, const T& t2, const T& eff_poly) const
+    { 
+        return std::exp(dPhi(t1, t2) * eff_poly / r);
+    }
+
+#ifdef LIBTHERMO_USE_XTENSOR
+    template<class T, class E, IS_XTENSOR>
+    auto RealGas::PR(const T& t1, const T& t2, const E& eff_poly) const
+    { 
+        return xt::exp(dPhi(t1, t2) * eff_poly / r);
+    }
+#endif
+
+    template<class T, IS_NOT_XTENSOR>
+    auto RealGas::EffPoly(const T& p1, const T& t1, const T& p2, const T& t2) const
+    {
+        return R<T>() * log(p2 / p1) / dPhi(t1, t2);
+    }
+
+#ifdef LIBTHERMO_USE_XTENSOR
+    template<class T, IS_XTENSOR>
+    auto RealGas::EffPoly(const T& p1, const T& t1, const T& p2, const T& t2) const
+    {
+        return R<double>() * xt::log(p2 / p1) / dPhi(t1, t2);
+    }
+#endif
+}
+#endif

--- a/pythermo/ideal.cpp
+++ b/pythermo/ideal.cpp
@@ -5,6 +5,7 @@
 // The full license is in the file LICENSE, distributed with this software.
 
 #include "libthermo/ideal_gas.h"
+#include "libthermo/real_gas.h"
 
 #include <pybind11/pybind11.h>
 #define FORCE_IMPORT_ARRAY
@@ -44,6 +45,7 @@ PYBIND11_MODULE(pythermo, m)
   //.def("gamma", &IdealGas::Gamma<double>, "Specific heat ratio", py::arg("temperature"))
   .def("specific_heat_pressure", &IdealGas::SpecificHeatPressure<double>, "Specific heat pressure", py::arg("temperature"))
   .def("cp", &IdealGas::Cp<double>, "Specific heat pressure", py::arg("temperature"))
+  .def("cp", &IdealGas::Cp<array_type>, "Specific heat pressure", py::arg("temperature"))
   .def("pressure_ratio", &IdealGas::PressureRatio<double>, "Pressure Ratio", py::arg("initiale temperature"), py::arg("finale temperature"), py::arg("polytropic efficiency"))
   //.def("pr", &IdealGas::PR<double>, "Pressure Ratio", py::arg("initiale temperature"), py::arg("finale temperature"), py::arg("polytropic efficiency"))
   .def("pr", &IdealGas::PR<array_type, array_type>, "Pressure Ratio", py::arg("initiale temperature"), py::arg("finale temperature"), py::arg("polytropic efficiency"))
@@ -55,5 +57,29 @@ PYBIND11_MODULE(pythermo, m)
   .def("polytropic_efficiency", &IdealGas::PolytropicEfficiency<double>, "Polytropic efficiency", 
         py::arg("initial pressure"), py::arg("initial temperature"), py::arg("final pressure"), py::arg("final temperature"));
 
+  py::class_<RealGas> (m, "RealGas")
+  .def(py::init<double>())
+  .def("constant", &RealGas::Constant<double>, "Gas constant")
+  .def("r", &RealGas::R<double>, "Gas constant")
+  .def("enthalpy", &RealGas::Enthalpy<double>, "Enthalpy", py::arg("temperature"))
+  .def("h", &RealGas::H<double>, "Enthalpy", py::arg("temperature"))
+  .def("entropy", &RealGas::Entropy<double>, "Entropy", py::arg("temperature"))
+  .def("phi", &RealGas::Phi<double>, "Entropy", py::arg("temperature"))
+  .def("phi", &RealGas::Phi<array_type>, "Entropy", py::arg("temperature"))
+  //.def("specific_heat_ratio", &IdealGas::SpecificHeatRatio<double>, "Specific heat ratio", py::arg("temperature"))
+  //.def("gamma", &IdealGas::Gamma<double>, "Specific heat ratio", py::arg("temperature"))
+  .def("specific_heat_pressure", &RealGas::SpecificHeatPressure<double>, "Specific heat pressure", py::arg("temperature"))
+  .def("cp", &RealGas::Cp<double>, "Specific heat pressure", py::arg("temperature"))
+  .def("cp", &RealGas::Cp<array_type>, "Specific heat pressure", py::arg("temperature"))
+  .def("pressure_ratio", &RealGas::PressureRatio<double>, "Pressure Ratio", py::arg("initiale temperature"), py::arg("finale temperature"), py::arg("polytropic efficiency"))
+  //.def("pr", &RealGas::PR<double>, "Pressure Ratio", py::arg("initiale temperature"), py::arg("finale temperature"), py::arg("polytropic efficiency"))
+  .def("pr", &RealGas::PR<array_type, array_type>, "Pressure Ratio", py::arg("initiale temperature"), py::arg("finale temperature"), py::arg("polytropic efficiency"))
+  .def("pr", &RealGas::PR<array_type, double>, "Pressure Ratio", py::arg("initiale temperature"), py::arg("finale temperature"), py::arg("polytropic efficiency"))
+  .def("eff_poly", &RealGas::EffPoly<double>, "Polytropic efficiency", 
+        py::arg("initial pressure"), py::arg("initial temperature"), py::arg("final pressure"), py::arg("final temperature"))
+  .def("eff_poly", &RealGas::PolytropicEfficiency<array_type>, "Polytropic efficiency", 
+        py::arg("initial pressure"), py::arg("initial temperature"), py::arg("final pressure"), py::arg("final temperature"))
+  .def("polytropic_efficiency", &RealGas::PolytropicEfficiency<double>, "Polytropic efficiency", 
+        py::arg("initial pressure"), py::arg("initial temperature"), py::arg("final pressure"), py::arg("final temperature"));
 }
 


### PR DESCRIPTION
Description
---

Add a polynomial gas model for real gas
- add a `polyval` function using universal refs
- implement `RealGas` using [Antares coefficients](https://www.cerfacs.fr/antares/_downloads/6d913fcaec57101ff421a2220b0769db/antares_doc.pdf) (p272)
- update benchs to test `RealGas`
- move optional xtensor macros to *gas.h*